### PR TITLE
Update community call workflow to run on 3rd Wednesday (one day before the Community call) of each month

### DIFF
--- a/.github/workflows/bot-en.yml
+++ b/.github/workflows/bot-en.yml
@@ -13,16 +13,26 @@ jobs:
       - name: Check if meeting week
         id: check_week
         run: |-
-          # Reference date: October 16, 2024 (last meeting)
-          REFERENCE_DATE="2024-10-16"
+          # Check if today is Wednesday and tomorrow is the 3rd Thursday of the month
           TODAY=$(date +%Y-%m-%d)
+          TOMORROW=$(date -d "+1 day" +%Y-%m-%d)
 
-          # Calculate days since reference date
-          DAYS_DIFF=$(( ( $(date -d "$TODAY" +%s) - $(date -d "$REFERENCE_DATE" +%s) ) / 86400 ))
+          # Check if today is Wednesday
+          if [ $(date +%u) -eq 3 ]; then
+            # Check if tomorrow is Thursday
+            if [ $(date -d "$TOMORROW" +%u) -eq 4 ]; then
+              # Get the day of the month for tomorrow
+              DAY_OF_MONTH=$(date -d "$TOMORROW" +%d)
 
-          # Check if it's exactly a multiple of 28 days (4 weeks) and today is Wednesday
-          if [ $(date +%u) -eq 3 ] && [ $(expr $DAYS_DIFF % 28) -eq 0 ] && [ $DAYS_DIFF -gt 0 ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+              # Third Thursday is between 15th and 21st of the month
+              if [ $DAY_OF_MONTH -ge 15 ] && [ $DAY_OF_MONTH -le 21 ]; then
+                echo "should_run=true" >> $GITHUB_OUTPUT
+              else
+                echo "should_run=false" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi
@@ -42,7 +52,7 @@ jobs:
           body: |-
             KubeVela Community Meetings
 
-            Every four weeks we host a community meeting to showcase new features, review upcoming milestones, and engage in Q&A with the KubeVela community - all are welcome, and we encourage participation.
+            Every month on the third Thursday we host a community meeting to showcase new features, review upcoming milestones, and engage in Q&A with the KubeVela community - all are welcome, and we encourage participation.
 
             The purpose of this thread is to form a discussion amongst the KubeVela community on potential topics to highlight during the meeting. If you have a topic you wish to present or learn more about, please comment and be sure to include your name and a short description of the topic.
 


### PR DESCRIPTION
Update community call workflow to run on 3rd Wednesday (one day before the Community call) of each month

**Summary**
This PR updates the English community call workflow to run monthly on the 3rd Wednesday (one day before the Community call) and fixes the workflow to skip gracefully instead of failing on non-meeting weeks.

**Changes**
**Schedule:** Changed to run every Wednesday at 15:00 UTC (8:00 AM PST)
**Frequency:** Updated to monthly on the 3rd Thursday of each month (instead of every 3 weeks)
**Logic:** Checks if tomorrow is the 3rd Thursday (days 15-21 of the month)
**Meeting time:** Updated to Thursday 8:00 AM PST (from Tuesday 7:30 AM)
**Issue timing:** Issue is created 24 hours before the meeting (Wednesday) to allow community members to add agenda items
**Workflow behavior:** Fixed to skip gracefully on non-meeting weeks instead of exiting with error code 1
**Manual testing:** Added workflow_dispatch trigger to allow manual testing

**Meeting Schedule**
The workflow will automatically create issues on the Wednesday before the 3rd Thursday of each month:
November 19, 2025 (Wednesday) - Issue created for November 20, 2025 meeting
December 17, 2025 (Wednesday) - Issue created for December 18, 2025 meeting
January 14, 2026 (Wednesday) - Issue created for January 15, 2025 meeting
And so on...

Each community meeting occurs on the 3rd Thursday of the month at 8:00 AM PST.

**Testing**
Tested manually in fork with successful issue creation.