### PR TITLE
ci: add keepalive workflow to prevent scheduled workflow auto-disable

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,13 @@
+name: Keepalive
+on:
+  schedule:
+    - cron: "0 12 1,15 * *"
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
## Summary

Adds a `Keepalive` workflow that periodically re-enables disabled scheduled workflows via the GitHub Actions API. This prevents the community call bot workflows (`bot-en.yml`, `bot-cn.yml`) from going silent during quiet periods on `main`.

## Why this is needed

GitHub automatically disables scheduled workflows after 60 days of repository inactivity. This already happened:

- Last commit on `main`: **2026-03-05** (#265 — add Vortexa to ADOPTERS.md)
- Last successful bot run: **2026-05-06**
- 60-day inactivity cutoff hit around **2026-05-05**
- Missed runs: **Wed May 13** and **Wed May 20** — the May 20 run was the one that would have created the **3rd-Thursday May 21** community call issue

As a result, no community call issue was created for May 2026.

## How the fix works

`liskin/gh-workflow-keepalive@v1` calls the Actions API to re-enable any disabled workflows in the repo. It runs twice a month (1st and 15th at 12:00 UTC), so even a fully quiet repo stays armed for the next 3rd-Thursday cron. No empty commits, no git-history pollution.

After merge, the first scheduled keepalive run on **Jun 1** will re-enable the disabled bots — well before the **Jun 17** community call cron needs to fire for the **Jun 18** (3rd Thursday) meeting.

## Test plan

- [ ] Merge PR
- [ ] Confirm Keepalive run on **Jun 1** completes successfully
- [ ] Confirm `Weekly Community Call (EN)` and the CN counterpart show as enabled in the Actions tab afterward
- [ ] Verify the **Jun 17** scheduled run fires and creates the 3rd-Thursday issue